### PR TITLE
fix a bug with cd-workflow.yml

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -59,6 +59,7 @@ jobs:
         name: webpack artifacts
         path: public
     - name: Build container image
+      # uses: docker/build-push-action@v2
       uses: docker/build-push-action@v2
       with:
         username: ${{github.actor}}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -59,11 +59,10 @@ jobs:
         name: webpack artifacts
         path: public
     - name: Build container image
-      # uses: docker/build-push-action@v2
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v1
       with:
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}
         registry: docker.pkg.github.com
-        repository: Guaand/github-actions-for-packages/tic-tac-toe
+        repository: guaand/github-actions-for-packages/tic-tac-toe
         tag_with_sha: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # Your Dockerfile contents go here!
-# edit anything
+# edit anything to trigger off GitHub Action
 FROM nginx:1.17
 COPY . /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # Your Dockerfile contents go here!
-
+# edit anything
 FROM nginx:1.17
 COPY . /usr/share/nginx/html


### PR DESCRIPTION
Original error in GitHub Action:
> 23 Building image [docker.pkg.github.com/Guaand/github-actions-for-packages/tic-tac-toe:sha-fa3c49b]
> 24 invalid argument "docker.pkg.github.com/Guaand/github-actions-for-packages/tic-tac-toe:sha-fa3c49b" for "-t, --tag" flag: invalid reference format: repository name must be lowercase

So, I changed the cd-workflow.yml:
> 67 "Guaand" into "guaand"

Then, I edited Dockerfile to trigger off GitHub Action.